### PR TITLE
Implement placeholder parsing 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7309d9b4d3d2c0641e018d449232f2e28f1b22933c137f157d3dbc14228b8c0e"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "aho-corasick 1.0.1",
  "memchr",
@@ -517,9 +537,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rustix"
@@ -603,6 +623,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "utas"
 version = "0.1.0"
 dependencies = [
@@ -611,10 +637,13 @@ dependencies = [
  "assert_fs",
  "clap",
  "configparser",
+ "const_format",
  "file",
  "indexmap",
+ "lazy_static",
  "predicates",
  "queues",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ configparser = { version = "3.0.2", features = ["indexmap"] }
 queues = { version = "1.0.2" }
 indexmap = { version = "1.9.3" }
 file = { path = "crates/file", version = "0.1.0" }
+regex = "1.8.3"
+lazy_static = "1.4.0"
+const_format = "0.2.30"
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.11" }

--- a/src/android_gen.rs
+++ b/src/android_gen.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Ok, Result};
 use std::collections::{hash_map, HashMap};
 
-use crate::parse::{File, Key, LocalizedString, Section, Token};
+use crate::parse::{File, Key, LocalizedString, Section};
 
 #[derive(PartialEq, Eq, Hash, Debug, PartialOrd, Ord, Clone)]
 pub struct Locale {
@@ -46,16 +46,11 @@ pub fn generate(source: &File) -> Result<GenResult> {
     Ok(GenResult { value: result })
 }
 
-pub fn generate_str_value(str_name: &String, tokens: &Vec<Token>) -> String {
+pub fn generate_str_value(str_name: &String, str_value: &str) -> String {
     let open_tag = format!("<string name=\"{}\">", str_name);
     let close_tag = "</string>";
     let mut value = String::from(open_tag);
-    for token in tokens {
-        match token {
-            Token::Text(text) => value.push_str(text),
-            Token::Placeholder(id) => value.push_str(id),
-        };
-    }
+    value.push_str(str_value);
     value.push_str(close_tag);
     value
 }
@@ -64,7 +59,7 @@ pub fn generate_str_value(str_name: &String, tokens: &Vec<Token>) -> String {
 fn plain_str(lang: &str, txt: &str) -> LocalizedString {
     LocalizedString {
         language_code: lang.to_string(),
-        value: vec![Token::Text(txt.to_string())],
+        value: txt.to_string(),
     }
 }
 
@@ -206,11 +201,7 @@ fn generate_3_lang_2_str() -> Result<()> {
 fn generate_1_lang_1_str_2_placeholders() -> Result<()> {
     let localizations_add = vec![LocalizedString {
         language_code: "mn".to_string(),
-        value: vec![
-            Token::Placeholder("%1$s".to_string()),
-            Token::Text(" нэмэх ".to_string()),
-            Token::Placeholder("%2$d".to_string()),
-        ],
+        value: "%1$s нэмэх %2$d".to_string(),
     }];
     let keys = vec![key("add", localizations_add)];
     let source = File {
@@ -239,6 +230,6 @@ fn generate_error_if_empty_sections() -> Result<()> {
 
     let actual = generate(&source);
     assert!(actual.is_err());
-    
+
     Ok(())
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -25,7 +25,7 @@ pub struct LocalizedString {
     pub value: Vec<Token>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Token {
     Text(String),
     Placeholder(String),
@@ -91,4 +91,75 @@ fn key_from_locale_value_map(
 fn parse_localized_string_value(raw_value: String) -> Result<Vec<Token>, String> {
     // TODO @dz actually parse
     Ok(vec![Token::Text(raw_value)])
+}
+
+#[test]
+fn parses_simple_string() {
+    let input = "Lorem ipsum".to_string();
+    let result = parse_localized_string_value(input).unwrap();
+    assert_eq!(result, vec![Token::Text("Lorem ipsum".to_string())]);
+}
+
+#[test]
+fn parses_single_placeholder() {
+    let input = "Lorem %d ipsum".to_string();
+    let result = parse_localized_string_value(input).unwrap();
+    assert_eq!(
+        result,
+        vec![
+            Token::Text("Lorem ".to_string()),
+            Token::Placeholder("%d".to_string()),
+            Token::Text(" ipsum".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn parses_single_string_placeholder() {
+    let input = "Lorem %@ ipsum".to_string();
+    let result = parse_localized_string_value(input).unwrap();
+    assert_eq!(
+        result,
+        vec![
+            Token::Text("Lorem ".to_string()),
+            Token::Placeholder("%s".to_string()),
+            Token::Text(" ipsum".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn parses_multiple_placeholders() {
+    let input = "Lorem %@ ipsum %.2f sir %,d amet %%".to_string();
+    let result = parse_localized_string_value(input).unwrap();
+    assert_eq!(
+        result,
+        vec![
+            Token::Text("Lorem ".to_string()),
+            Token::Placeholder("%1$s".to_string()),
+            Token::Text(" ipsum ".to_string()),
+            Token::Placeholder("%2$.2f".to_string()),
+            Token::Text(" sir ".to_string()),
+            Token::Placeholder("%3$,d".to_string()),
+            Token::Text(" amet %%".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn parses_multiple_placeholders_keeping_order_if_present() {
+    let input = "Lorem %3$@ ipsum %1$.2f sir %2$,d amet".to_string();
+    let result = parse_localized_string_value(input).unwrap();
+    assert_eq!(
+        result,
+        vec![
+            Token::Text("Lorem ".to_string()),
+            Token::Placeholder("%3$s".to_string()),
+            Token::Text(" ipsum ".to_string()),
+            Token::Placeholder("%1$.2f".to_string()),
+            Token::Text(" sir ".to_string()),
+            Token::Placeholder("%2$,d".to_string()),
+            Token::Text(" amet".to_string()),
+        ]
+    );
 }


### PR DESCRIPTION
The only thing left unsupported for now is turning "%" into "%%".
Twine internally uses regexp negative lookahead for this which is not
supported by the Regex crate, so something else will have to be
done (added draft of what I plan to do as a code comment).