### PR TITLE
Add build release workflow

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -1,0 +1,59 @@
+name: Linux Realse
+on:
+  push:
+    tags: [ "*release" ]
+
+env:
+  RELEASE_ARCHIVE_NAME: utas-release
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Run tests
+      run: cargo test --verbose
+
+    - name: Run crate file tests
+      run: cargo test -p file
+
+  linux-build-release:
+    runs-on: ubuntu-latest
+    needs:  tests
+    permissions:
+       contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      run: cargo build --release --verbose
+      
+    - name: Compress assets
+      run: |
+        cd target
+        tar cfv "$RELEASE_ARCHIVE_NAME".tar.gz release/utas
+
+    - name: Create release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref_name }}
+        release_name: Utas-Linux release ${{ github.ref_name }}
+        draft: true
+        prerelease: false
+
+    - name: Upload assets
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ASSET_PATH: ${{ github.workspace }}/target/${{ env.RELEASE_ARCHIVE_NAME }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ env.ASSET_PATH }}.tar.gz
+        asset_name: ${{ env.RELEASE_ARCHIVE_NAME }}-linux.tar.gz
+        asset_content_type: application/x-gtar

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -1,0 +1,59 @@
+name: MacOs Release
+on:
+  push:
+    tags: [ "*release" ]
+
+env:
+  RELEASE_ARCHIVE_NAME: utas-release
+
+jobs:
+  tests:
+    runs-on: macos-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Run tests
+      run: cargo test --verbose
+
+    - name: Run crate file tests
+      run: cargo test -p file
+
+  mac-build-release:
+    runs-on: macos-latest
+    needs:  tests
+    permissions:
+       contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      run: cargo build --release --verbose
+      
+    - name: Compress assets
+      run: |
+        cd target
+        zip -r "$RELEASE_ARCHIVE_NAME".zip release/utas
+
+    - name: Create release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref_name }}
+        release_name: Utas-MacOs release ${{ github.ref_name }}
+        draft: true
+        prerelease: false
+
+    - name: Upload assets
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ASSET_PATH: ${{ github.workspace }}/target/${{ env.RELEASE_ARCHIVE_NAME }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ env.ASSET_PATH }}.zip
+        asset_name: ${{ env.RELEASE_ARCHIVE_NAME }}-mac-os.zip
+        asset_content_type: application/zip

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,12 +1,9 @@
-name: CI
+name: Debug build and tests
 on:
   push:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
-
-env:
-  CARGO_TERM_COLOR: always
 
 jobs:
   build:
@@ -14,10 +11,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
+
     - name: Build
       run: cargo build --verbose
+
     - name: Run tests
       run: cargo test --verbose
+
     - name: Run crate file tests
       run: cargo test -p file

--- a/.github/workflows/win-release.yml
+++ b/.github/workflows/win-release.yml
@@ -1,0 +1,59 @@
+name: Windows Release
+on:
+  push:
+    tags: [ "*release" ]
+
+env:
+  RELEASE_ARCHIVE_NAME: utas-release
+
+jobs:
+  tests:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Run tests
+      run: cargo test --verbose
+
+    - name: Run crate file tests
+      run: cargo test -p file
+
+  windows-build-release:
+    runs-on: windows-latest
+    needs:  tests
+    permissions:
+       contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      run: cargo build --release --verbose
+      
+    - name: Compress assets
+      run: |
+        cd target
+        powershell Compress-Archive -LiteralPath 'release/utas.exe' -DestinationPath '${{ env.RELEASE_ARCHIVE_NAME }}.zip'
+
+    - name: Create release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref_name }}
+        release_name: Utas-Windows release ${{ github.ref_name }}
+        draft: true
+        prerelease: false
+
+    - name: Upload assets
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ASSET_PATH: ${{ github.workspace }}/target/${{ env.RELEASE_ARCHIVE_NAME }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ env.ASSET_PATH }}.zip
+        asset_name: ${{ env.RELEASE_ARCHIVE_NAME }}-windows.zip
+        asset_content_type: application/zip


### PR DESCRIPTION
У меня походу нет прав, поэтому тут ничего не собралось. В моем форке в закрытом пр получалось. 
Хотел сделать так:
           linux release                                            upload linux assets
test -> mac release -> create github release -> upload mac assets
           win release                                              upload win assets

Но загрузка ассетов не может получить workflow.env c предыдущих шагов, ставил прям тег платформы такой же, но все равно нет. Можно сделать с помощью outputs джобов, но там кажется в целом можно передвать только что-то легкое и в целом для передачи артефактов не годится. Чтобы и шарить, нужно запускать свой контейнер, в который складываться туда всё, но мне кажется так уже отношение пользы к трудности уже маленькое, поэтому сделал все отдельно. 

Для раст есть такаое: 
https://github.com/marketplace/actions/rust-release-binary, но во первых оно какое-то полузаброшенное, и
![image](https://github.com/appKODE/utas/assets/32998850/934d5d44-bc5a-40c9-83da-2938576628db)

Ну и в целом не вижу для нашего проекта преимущества.

P.S.: сейчас глянул артефакты, и походу придется потом подправить. потому что почему-то на винде и на маке весит подозрительно мало. Но это в целом сильно на скрипты не повлияет, можно потом дозакинуть. 
