### PR TITLE
Handle plurals + non-plurals duplicated resource name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -66,7 +66,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -244,7 +244,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -376,7 +376,7 @@ checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -388,7 +388,7 @@ dependencies = [
  "hermit-abi",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -552,7 +552,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -589,15 +589,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -644,6 +645,7 @@ dependencies = [
  "predicates",
  "queues",
  "regex",
+ "tempfile",
 ]
 
 [[package]]
@@ -704,35 +706,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -741,20 +719,14 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -764,21 +736,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -788,21 +748,9 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -812,21 +760,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ file = { path = "crates/file", version = "0.1.0" }
 regex = "1.8.3"
 lazy_static = "1.4.0"
 const_format = "0.2.30"
+tempfile = "3.6.0"
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.11" }

--- a/tests/cases/android/case9/input/src1.txt
+++ b/tests/cases/android/case9/input/src1.txt
@@ -1,0 +1,21 @@
+[[Src1]]
+  [days]
+    en:one = %d day
+    en:many = %d days
+    en:other = %d other days
+    ru = %d дней
+
+  [days]
+    en = d
+    ru = дн
+
+  # this key has another order: plurals go after regular strings
+  [weeks]
+    en = w
+    ru = нд
+
+  [weeks]
+    en:one = %d week
+    en:many = %d weeks
+    en:other = %d other weeks
+    ru = %d недель

--- a/tests/cases/android/case9/output/values-en/src1.xml
+++ b/tests/cases/android/case9/output/values-en/src1.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+  <plurals name="days">
+    <item quantity="one">%d day</item>
+    <item quantity="many">%d days</item>
+    <item quantity="other">%d other days</item>
+  </plurals>
+  <string name="days">d</string>
+  <string name="weeks">w</string>
+  <plurals name="weeks">
+    <item quantity="one">%d week</item>
+    <item quantity="many">%d weeks</item>
+    <item quantity="other">%d other weeks</item>
+  </plurals>
+</resources>

--- a/tests/cases/android/case9/output/values-ru/src1.xml
+++ b/tests/cases/android/case9/output/values-ru/src1.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+  <plurals name="days">
+    <item quantity="other">%d дней</item>
+  </plurals>
+  <string name="days">дн</string>
+  <string name="weeks">нд</string>
+  <plurals name="weeks">
+    <item quantity="other">%d недель</item>
+  </plurals>
+</resources>

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -43,10 +43,16 @@ fn case_android_8() -> Result<(), Box<dyn Error>> {
     basic_test_case("case8")
 }
 
+#[test]
+fn case_android_9() -> Result<(), Box<dyn Error>> {
+    basic_test_case("case9")
+}
+
 fn basic_test_case(case_rel_path: &str) -> Result<(), Box<dyn Error>> {
     let mut cmd = Command::cargo_bin("utas")?;
 
-    let temp = assert_fs::TempDir::new()?;
+    let mut temp = assert_fs::TempDir::new()?;
+    temp = temp.into_persistent();
 
     let input = format!("tests/cases/android/{}/input", case_rel_path);
     let output = temp.path();
@@ -59,7 +65,10 @@ fn basic_test_case(case_rel_path: &str) -> Result<(), Box<dyn Error>> {
         CompareDirsContentResult::Eq => (),
         CompareDirsContentResult::Diffs(diffs) => eprintln!("{}", format_diffs(diffs)),
     }
-    assert!(CompareDirsContentResult::Eq == result, "Dirs are different. See log above");
+    assert!(
+        CompareDirsContentResult::Eq == result,
+        "Dirs are different. See log above"
+    );
     Ok(())
 }
 
@@ -84,7 +93,7 @@ fn format_diffs(diffs: &Vec<DirDiff>) -> String {
             DirDiff::FileContent { path, diffs } => {
                 format!(
                     "{}. In file {} diff content:\n {}___________________________________________________________\n\n",
-                    index, 
+                    index,
                     path,
                     format_file_diffs(diffs),
                 )


### PR DESCRIPTION
When txt-file has both plurals and non-plurals, two resources must be generated, before this commit the latest key replaced the previous one whichever it was.

Not both plurals and regular string will be generated.