### PR TITLE
Fix issues with escaping html tags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,15 +19,22 @@ fn main() -> Result<()> {
     run_android_gen_pipeline(&args.input_dir, &args.output_dir, &args.default_lang)
 }
 
-fn run_android_gen_pipeline(input_dir: &String, output_dir: &String, default_lang: &Option<String>) -> Result<()> {
+fn run_android_gen_pipeline(
+    input_dir: &String,
+    output_dir: &String,
+    default_lang: &Option<String>,
+) -> Result<()> {
     for src in fs::read_dir(input_dir)? {
         let src = src?;
         if src.file_type()?.is_file() {
             let parsed = parser::parse(src.path()).map_err(|err| anyhow!(err))?;
             let generated = generator::generate(&parsed)?;
             generated.write(
-                output_dir, 
-                src.path().file_stem().and_then(|os_str| os_str.to_str()).ok_or(anyhow!("Cannot extract file name"))?,
+                output_dir,
+                src.path()
+                    .file_stem()
+                    .and_then(|os_str| os_str.to_str())
+                    .ok_or(anyhow!("Cannot extract file name"))?,
                 default_lang,
             )?;
         }


### PR DESCRIPTION
Now additional rules are the following:

- Do not escape any tags supported by Android (see https://developer.android.com/guide/topics/resources/string-resource.html#StylingWithHTML)
- Do not escape double quotes within supported tags