### PR TITLE
Remove ';' from comment symbols

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -79,6 +79,7 @@ pub fn parse<T: AsRef<Path>>(path: T) -> Result<File, String> {
     let mut default = IniDefault::default();
     default.case_sensitive = true;
     default.delimiters = vec!['='];
+    default.comment_symbols = vec!['#'];
     let mut config = Ini::new_from_defaults(default);
 
     // See NOTE_DEDUPLICATING_KEYS


### PR DESCRIPTION
This caused incorrect generation for strings like

<string>Terms &amp; Conditions</string>