### PR TITLE
Add iOS Generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 
 .vscode
+.DS_Store

--- a/crates/file/src/file.rs
+++ b/crates/file/src/file.rs
@@ -81,7 +81,11 @@ fn get_all_file_paths(dir: &Path) -> Result<Vec<Box<Path>>> {
                 dirs.add(Box::from(dir.join(item.file_name()).as_ref()))
                     .unwrap();
             } else {
-                paths.push(Box::from(item.path().as_path()))
+                // TODO move it to appropriate place (in file.rs shouldn't be any platform related concrecity)
+                // Skipping macOS system file
+                if item.file_name() != ".DS_Store" {
+                    paths.push(Box::from(item.path().as_path()))
+                }
             }
         }
         if dirs.size() == 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,15 @@
-use android_gen as generator;
 use anyhow::{anyhow, Ok, Result};
 use clap::Parser;
 use parse as parser;
 use std::fs;
 
 mod android_gen;
+mod ios_gen;
 mod parse;
 
 #[derive(Parser)]
 struct Args {
+    platform: String,
     input_dir: String,
     output_dir: String,
     default_lang: Option<String>,
@@ -16,7 +17,21 @@ struct Args {
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    run_android_gen_pipeline(&args.input_dir, &args.output_dir, &args.default_lang)
+    run_gen_pipeline(&args.platform, &args.input_dir, &args.output_dir, &args.default_lang)
+}
+
+fn run_gen_pipeline(
+    platform: &String,
+    input_dir: &String,
+    output_dir: &String,
+    default_lang: &Option<String>,
+) -> Result<()> {
+    // TODO add enum for Platform parameter
+    return match platform.as_str() {
+        "android" => run_android_gen_pipeline(input_dir, output_dir, default_lang),
+        "ios" => run_ios_gen_pipeline(input_dir, output_dir, default_lang),
+        _ => panic!("Invalid platform parameter. Use android or ios")
+    };
 }
 
 fn run_android_gen_pipeline(
@@ -28,7 +43,30 @@ fn run_android_gen_pipeline(
         let src = src?;
         if src.file_type()?.is_file() {
             let parsed = parser::parse(src.path()).map_err(|err| anyhow!(err))?;
-            let generated = generator::generate(&parsed)?;
+            let generated = android_gen::generate(&parsed)?;
+            generated.write(
+                output_dir,
+                src.path()
+                    .file_stem()
+                    .and_then(|os_str| os_str.to_str())
+                    .ok_or(anyhow!("Cannot extract file name"))?,
+                default_lang,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn run_ios_gen_pipeline(
+    input_dir: &String,
+    output_dir: &String,
+    default_lang: &Option<String>,
+) -> Result<()> {
+    for src in fs::read_dir(input_dir)? {
+        let src = src?;
+        if src.file_type()?.is_file() {
+            let parsed = parser::parse(src.path()).map_err(|err| anyhow!(err))?;
+            let generated = ios_gen::generate(&parsed)?;
             generated.write(
                 output_dir,
                 src.path()

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,70 +6,71 @@ use std::{error::Error, path::Path};
 
 #[test]
 fn case_android_1() -> Result<(), Box<dyn Error>> {
-    basic_test_case("case1", None)
+    basic_test_case("android", "case1", None)
 }
 
 #[test]
 fn case_android_2() -> Result<(), Box<dyn Error>> {
-    basic_test_case("case2", None)
+    basic_test_case("android", "case2", None)
 }
 
 #[test]
 fn case_android_3() -> Result<(), Box<dyn Error>> {
-    basic_test_case("case3", None)
+    basic_test_case("android", "case3", None)
 }
 
 #[test]
 fn case_android_4() -> Result<(), Box<dyn Error>> {
-    basic_test_case("case4", None)
+    basic_test_case("android", "case4", None)
 }
 
 #[test]
 fn case_android_5() -> Result<(), Box<dyn Error>> {
-    basic_test_case("case5", None)
+    basic_test_case("android", "case5", None)
 }
 
 #[test]
 fn case_android_6() -> Result<(), Box<dyn Error>> {
-    basic_test_case("case6", None)
+    basic_test_case("android", "case6", None)
 }
 
 #[test]
 fn case_android_7() -> Result<(), Box<dyn Error>> {
-    basic_test_case("case7", None)
+    basic_test_case("android", "case7", None)
 }
 
 #[test]
 fn case_android_8() -> Result<(), Box<dyn Error>> {
-    basic_test_case("case8", None)
+    basic_test_case("android", "case8", None)
 }
 
 #[test]
 fn case_android_9() -> Result<(), Box<dyn Error>> {
-    basic_test_case("case9", None)
+    basic_test_case("android", "case9", None)
 }
 
 #[test]
 fn case_android_10() -> Result<(), Box<dyn Error>> {
-    basic_test_case("case10", Some("ru".to_string()))
+    basic_test_case("android", "case10", Some("ru".to_string()))
 }
 
 #[test]
 fn case_android_11() -> Result<(), Box<dyn Error>> {
-    basic_test_case("case11", Some("mn".to_string()))
+    basic_test_case("android", "case11", Some("mn".to_string()))
 }
 
 #[test]
 fn case_android_12() -> Result<(), Box<dyn Error>> {
-    basic_test_case("case12", None)
+    basic_test_case("android", "case12", None)
 }
 
 #[test]
 fn case_android_13() -> Result<(), Box<dyn Error>> {
-    basic_test_case("case13", None)
+    basic_test_case("android", "case13", None)
 }
 
 fn basic_test_case(
+    platform: &str,
     case_rel_path: &str,
     default_lang: Option<String>,
 ) -> Result<(), Box<dyn Error>> {
@@ -90,7 +91,8 @@ fn basic_test_case(
         .join(case_rel_path)
         .join("output");
 
-    cmd.arg(Path::new(&input).as_os_str())
+    cmd.arg(&platform)
+        .arg(Path::new(&input).as_os_str())
         .arg(output.as_os_str());
     if default_lang.is_some() {
         cmd.arg(default_lang.unwrap());


### PR DESCRIPTION
I added generation for iOS with new agrument for platform. Cloned all structures and examples from android, didn't know what to do with them.
There are few moments requiring improvements imo, I don't know Rust enough to resolve them myself.

Tests will be in another PR because I want them (PRs) to be atomic.

**Example of generated files:**
Source file:

```
[[Src1]]
  [lorem]
    en = Lorem %d ipsumkekum
    ru = Лорем %d ипсумкекум

  [ooo]
    en = Ooooo %@ ooooO 
    ru = Ооооо %@ ооооО
```

<img width="230" alt="Directory structure" src="https://github.com/appKODE/utas/assets/16734454/aa9077b1-39cd-4727-99c4-0fb48d4b9bdb">

en.lproj/Localizable.strings:
```
"lorem" = "Lorem %d ipsumkekum";
"ooo" = "Ooooo %s ooooO";
```
